### PR TITLE
#158275579: Admin disapprove request

### DIFF
--- a/server/public/js/adminrequest.js
+++ b/server/public/js/adminrequest.js
@@ -15,8 +15,8 @@ const getAllUsersRequests = () => {
 
   const retrievedToken = localStorage.getItem('token');
 
-  const url = 'https://maintenance-tracker-andela.herokuapp.com/api/v1/requests/';
-  // const url = 'http://localhost:8000/api/v1/requests/';
+  // const url = 'https://maintenance-tracker-andela.herokuapp.com/api/v1/requests/';
+  const url = 'http://localhost:8000/api/v1/requests/';
 
   fetch(url, {
     method: 'get',
@@ -60,6 +60,13 @@ const getAllUsersRequests = () => {
         const resolveBtn = createNode('button');
         resolveBtn.setAttribute('id', 'resolve');
         resolveBtn.innerHTML = 'Resolve ';
+        resolveBtn.onmouseover = function() {
+          this.style.color = 'white';
+          this.style.cursor = 'pointer';
+        }
+        resolveBtn.onmouseleave = function() {
+          this.style.color = 'black';
+        }
 
         const resolveFont = createNode('i');
         resolveFont.setAttribute('class', 'far fa-check-square');
@@ -106,9 +113,10 @@ const getAllUsersRequests = () => {
           document.getElementById('description').innerHTML = `${request.description}`;
 
           const approveBtn = document.getElementById('greenbtn');
+          const disapproveBtn = document.getElementById('redbtn');
 
           approveBtn.addEventListener('click', () => {
-            const id = document.getElementById('requestId').innerHTML
+            const id = document.getElementById('requestId').innerHTML;
             return fetch(`${url}${id}/approve`, {
               method: 'put',
               mode: 'cors',
@@ -118,6 +126,22 @@ const getAllUsersRequests = () => {
             })
               .then(res => res.json())
               .then((requestApproved) => {
+                window.location.href = './adminrequest.html';
+                return null;
+              });
+          });
+
+          disapproveBtn.addEventListener('click', () => {
+            const id = document.getElementById('requestId').innerHTML;
+            return fetch(`${url}${id}/disapprove`, {
+              method: 'put',
+              mode: 'cors',
+              headers: {
+                'x-auth': retrievedToken,
+              },
+            })
+              .then(res => res.json())
+              .then((requestDisapproved) => {
                 window.location.href = './adminrequest.html';
                 return null;
               });


### PR DESCRIPTION
#### What does this PR do?

- This PR is to enable the setup to disapprove a request by the Admin by consuming the API endpoint for disapproving a request by its Id using fetch.

#### Description of Task to be completed?

- Write code to implement the functionality of the API consumption.

#### How should this be manually tested?

- After creating your account
- Navigate https://maintenance-tracker-andela.herokuapp.com/api/v1/users/requests
- Enter valid details in the form field, and you can start creating new requests
- Navigate to the admin request page if you are registered as an admin
- You should see all the requests that have been made
- Click on the Manage button and you can then disapprove a request by clicking on the reject button

#### What are the relevant pivotal tracker stories?

- Story type: Feature
- Story Id: #158275579

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/31142281/41261935-013e40ca-6dd6-11e8-838d-680282329abb.png)
